### PR TITLE
Adding parameter to disable JS minification to point to a quick worka…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,8 +62,9 @@ lastmod = ["lastmod", ":git", "date"]
     light = "#f8f9fa"
     dark = "#343a40"
 
-# Disable JS minification by turning the following flag to true
-# Workaround that solves the issue of the dropdown menu not being responsive
+# The following flag disables JS minification
+# If you encounter issues with the dropdown menu and the JavaScript controlling
+# it does not load properly, consider turning this to true.
 # See https://github.com/okkur/syna/issues/859 
 [minify]
 disableJS = false
@@ -83,7 +84,6 @@ disableJS = false
 
 [[menu.main]]
   url = "#contact"
-
   name = "Contact"
   weight = 30
 

--- a/config.toml
+++ b/config.toml
@@ -62,6 +62,12 @@ lastmod = ["lastmod", ":git", "date"]
     light = "#f8f9fa"
     dark = "#343a40"
 
+# Disable JS minification by turning the following flag to true
+# Workaround that solves the issue of the dropdown menu not being responsive
+# See https://github.com/okkur/syna/issues/859 
+[minify]
+disableJS = false
+
 # main/prepend/postpend menus are displayed in nav fragment.
 # Keep an eye out for updates. These will be moved out to make navbar more
 # configurable.
@@ -77,6 +83,7 @@ lastmod = ["lastmod", ":git", "date"]
 
 [[menu.main]]
   url = "#contact"
+
   name = "Contact"
   weight = 30
 


### PR DESCRIPTION
Hello!

Just a quick change to add to the `config.toml` file a reference to a workaround to an issue with the current version of the starter template. The issue is due to the JS minification process causing the dropdown menu not behaving anymore as responsive. 

I wished that these few lines had been in the file when I cloned the starter repo as this would have saved me some time trying to figure out a solution (I was almost at the point of switching completely of template/theme as this was not working, which is a shame as this is a cool template). So, decided to submit this PR in case this happens to anyone else. 

Best,
